### PR TITLE
Fixing url for when using search bar in docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -208,7 +208,7 @@ const config = {
       // Optional: Replace parts of the item URLs from Algolia. Useful when using the same search index for multiple deployments using a different baseUrl. You can use regexp or string in the `from` param. For example: localhost:3000 vs myCompany.com/docs
       replaceSearchResultPathname: {
         from: '/docs/', // or as RegExp: /\/docs\//
-        to: '/docs',
+        to: '/docs/',
       },
 
       // Optional: Algolia search parameters

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -208,7 +208,7 @@ const config = {
       // Optional: Replace parts of the item URLs from Algolia. Useful when using the same search index for multiple deployments using a different baseUrl. You can use regexp or string in the `from` param. For example: localhost:3000 vs myCompany.com/docs
       replaceSearchResultPathname: {
         from: '/docs/', // or as RegExp: /\/docs\//
-        to: '/',
+        to: '/docs',
       },
 
       // Optional: Algolia search parameters


### PR DESCRIPTION
There was an issue when using "search" in Docs, that it would always return "Page not found", but found when you manually add "/doc/" before the resulted URL, it works.

Replicate:
1: Open https://wiki.archcraft.io/
2: Click Docs 
3: Use the search bar (top right) and type in: Virtual Machines

Expected: See the Virtual Machines page.

Actual: See "Page Not Found"
![image](https://github.com/user-attachments/assets/744e2001-3832-4a3f-9c9e-06a8031550ef)

URL: https://wiki.archcraft.io/premium/wse/#virtual-machines

Should be: https://wiki.archcraft.io/docs/premium/wse/#virtual-machines


I hope this helps!